### PR TITLE
Fix LOGGING_LEVEL not working when Mattermost is not enabled.

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,12 +35,12 @@ rotating_handler = RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backu
 rotating_handler.setFormatter(log_formatter)
 
 if MATTERMOST_WEBHOOK_URL is None:
-    logging.warning("MATTERMOST_WEBHOOK_URL is not set. Mattermost notifications will not be sent.")
     logging.basicConfig(level=NUMERIC_LEVEL, format='%(asctime)s - %(levelname)s - %(message)s',
                         handlers=[
                             rotating_handler,
                             logging.StreamHandler()
                         ])
+    logging.warning("MATTERMOST_WEBHOOK_URL is not set. Mattermost notifications will not be sent.")
 else:
     mattermost_handler = MattermostHandler(MATTERMOST_WEBHOOK_URL)
     mattermost_handler.setFormatter(log_formatter)


### PR DESCRIPTION
### Problem repro

1. Set `LOGGING_LEVEL` to `DEBUG` in `.env` (the default)
2. Remove `MATTERMOST_WEBHOOK_URL` env var
3. Start the docker image

Expected: All logs are printed and added to `logs/app.log`. Example: `"Initializing database..."` at DEBUG level.
Actual: Only warning logs can be found.

### Root cause and fix

`logging.warning` implicitly calls `basicConfig` if no handlers are present. The default configuration has `level=WARNING`. After that, calls to `basicConfig` [does nothing](https://docs.python.org/3/library/logging.html#logging.basicConfig) because it has already been (implicitly) configured. Therefore, the level stays at `WARNING` and the file is not written to.

This PR fixes it by swapping the order to make sure `basicConfig` is called before the first log line.