### PR TITLE
Fix MQTT messages not triggering uploads.

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,8 +62,8 @@ def on_message(client, userdata, msg):
     logging.debug(f"MQTT message received `{msg.payload.decode()}` from topic `{msg.topic}`")
     event = json.loads(msg.payload)
     event_type = event.get('type', None)
-    end_time = event.get('end_time', None)
-    has_clip = event.get('has_clip', False)
+    end_time = event.get('after', {}).get('end_time', None)
+    has_clip = event.get('after', {}).get('has_clip', False)
 
     if event_type == 'end' and end_time is not None and has_clip is True:
         event_data = event['after']


### PR DESCRIPTION
### Problem repro

1. (Optional) Set `LOGGING_LEVEL` to `DEBUG` for easier observations
2. Trigger some motion on the camera
3. Watch logs and uploading progress in Google Drive

Expected: Uploading should immediately start after motion ends (triggered by MQTT event)

Actual:

- All events are ignored.
- Log lines indicate `Received a MQTT message but event type, end_time or has_clip doesn't interest us. Wait for the full message. Skipping...`
- Videos don't appear until the scheduled job every 3 minutes.

### Root cause and fix

MQTT message payload sent by Frigate has the following shape:

```json
{
  "type": "end",
  "before": {...},
  "after": {...}
}
```

Note that all interesting fields are nested under `before` / `after` except `type`. Therefore, we need to look into `.after.end_time` for example. The existing code tries to look for fields on the top level, and failing that, returns the default values.